### PR TITLE
feat: enhance drawing and measuring toolbar

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -737,10 +737,43 @@
       <div id="map_container" style="background-color:#D2D2D2;">
         <!-- MAP_CONTAINER_ANCHOR -->
         <div id="drawing_toolbar">
-          <button id="draw_marker" title="Add marker">M</button>
-          <button id="draw_line" title="Draw line">L</button>
-          <button id="measure" title="Measure distance">R</button>
-          <button id="clear_drawings" title="Clear drawings">C</button>
+          <button id="draw_marker" title="Add marker">
+            <svg viewBox="0 0 24 24">
+              <path d="M12 2a7 7 0 0 0-7 7c0 5.25 7 13 7 13s7-7.75 7-13a7 7 0 0 0-7-7zm0 9a2 2 0 1 1 0-4 2 2 0 0 1 0 4z"/>
+            </svg>
+          </button>
+          <button id="draw_line" title="Draw line">
+            <svg viewBox="0 0 24 24">
+              <line x1="4" y1="20" x2="20" y2="4" stroke-width="2"/>
+            </svg>
+          </button>
+          <button id="draw_polygon" title="Draw polygon">
+            <svg viewBox="0 0 24 24">
+              <polygon points="12,4 20,20 4,20" stroke-width="2"/>
+            </svg>
+          </button>
+          <button id="measure_line" title="Measure distance">
+            <svg viewBox="0 0 24 24">
+              <rect x="3" y="10" width="18" height="4" stroke-width="2"/>
+              <line x1="7" y1="10" x2="7" y2="14" stroke-width="1"/>
+              <line x1="11" y1="10" x2="11" y2="14" stroke-width="1"/>
+              <line x1="15" y1="10" x2="15" y2="14" stroke-width="1"/>
+              <line x1="19" y1="10" x2="19" y2="14" stroke-width="1"/>
+            </svg>
+          </button>
+          <button id="measure_area" title="Measure area">
+            <svg viewBox="0 0 24 24">
+              <rect x="4" y="4" width="16" height="16" stroke-width="2"/>
+              <line x1="4" y1="4" x2="20" y2="20" stroke-width="1"/>
+              <line x1="20" y1="4" x2="4" y2="20" stroke-width="1"/>
+            </svg>
+          </button>
+          <button id="clear_drawings" title="Clear drawings">
+            <svg viewBox="0 0 24 24">
+              <line x1="4" y1="4" x2="20" y2="20" stroke-width="2"/>
+              <line x1="20" y1="4" x2="4" y2="20" stroke-width="2"/>
+            </svg>
+          </button>
         </div>
         <div id="map_canvas" style="background-color:#D2D2D2;">
         </div>

--- a/html/script.js
+++ b/html/script.js
@@ -38,6 +38,7 @@ let realHeat;
 let drawSource = new ol.source.Vector();
 let drawLayer;
 let drawInteraction = null;
+let activeDrawButton = null;
 let iconCache = {};
 let addToIconCache = [];
 let lineStyleCache = {};
@@ -2876,6 +2877,16 @@ function initMap() {
     });
     layers.push(iconLayer);
 
+    function setActiveButton(btn) {
+        if (activeDrawButton) {
+            activeDrawButton.classList.remove('active');
+        }
+        activeDrawButton = btn;
+        if (btn) {
+            btn.classList.add('active');
+        }
+    }
+
     function activateDraw(type, measure) {
         removeDraw();
         drawInteraction = new ol.interaction.Draw({
@@ -2883,10 +2894,13 @@ function initMap() {
             type: type,
         });
         drawInteraction.on('drawend', function(evt) {
-            if (measure) {
-                const geom = evt.feature.getGeometry();
+            const geom = evt.feature.getGeometry();
+            if (measure === 'length') {
                 const length = geom.getLength();
                 alert('Length: ' + formatLength(length));
+            } else if (measure === 'area') {
+                const area = geom.getArea();
+                alert('Area: ' + formatArea(area));
             }
             removeDraw();
         });
@@ -2898,6 +2912,7 @@ function initMap() {
             OLMap.removeInteraction(drawInteraction);
             drawInteraction = null;
         }
+        setActiveButton(null);
     }
 
     function clearDrawings() {
@@ -2908,17 +2923,32 @@ function initMap() {
         return (length / 1000).toFixed(2) + ' km';
     }
 
+    function formatArea(area) {
+        return (area / 1000000).toFixed(2) + ' km²';
+    }
+
 
     ol_map_init();
 
     document.getElementById('draw_marker').addEventListener('click', function() {
+        setActiveButton(this);
         activateDraw('Point');
     });
     document.getElementById('draw_line').addEventListener('click', function() {
+        setActiveButton(this);
         activateDraw('LineString');
     });
-    document.getElementById('measure').addEventListener('click', function() {
-        activateDraw('LineString', true);
+    document.getElementById('draw_polygon').addEventListener('click', function() {
+        setActiveButton(this);
+        activateDraw('Polygon');
+    });
+    document.getElementById('measure_line').addEventListener('click', function() {
+        setActiveButton(this);
+        activateDraw('LineString', 'length');
+    });
+    document.getElementById('measure_area').addEventListener('click', function() {
+        setActiveButton(this);
+        activateDraw('Polygon', 'area');
     });
     document.getElementById('clear_drawings').addEventListener('click', function() {
         clearDrawings();

--- a/html/style.css
+++ b/html/style.css
@@ -106,19 +106,46 @@ select {
     top: 50px;
     left: 10px;
     z-index: 1000;
-    background: rgba(255,255,255,0.8);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    background: rgba(255,255,255,0.9);
     border-radius: 4px;
     padding: 4px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.3);
 }
 
 #drawing_toolbar button {
-    display: block;
     width: 32px;
     height: 32px;
-    margin: 2px 0;
-    background: #fff;
-    border: 1px solid #aaa;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     cursor: pointer;
+    border: none;
+    background: transparent;
+    color: var(--TXTCOLOR2);
+    border-radius: 4px;
+}
+
+#drawing_toolbar button:hover {
+    background: rgba(0,0,0,0.1);
+}
+
+#drawing_toolbar button.active {
+    background: var(--ACCENT);
+    color: #fff;
+}
+
+#drawing_toolbar button svg {
+    width: 20px;
+    height: 20px;
+    stroke: currentColor;
+    fill: none;
+}
+
+#drawing_toolbar button svg path {
+    fill: currentColor;
 }
 
 .sidebar_button {


### PR DESCRIPTION
## Summary
- redesign drawing toolbar with icons
- add polygon drawing and area measurement
- highlight active drawing tools

## Testing
- `node --check html/script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baf9072a5c83339ae23533f7b19c7f