### PR TITLE
Add black toolbar icons, marker overlays and coordinate footer

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -779,6 +779,7 @@
         </div>
         <div id="iconTestCanvas" style="background-color:#D2D2D2;display:none;">
         </div>
+        <div id="mouse-coordinates">Lat: ---, Lng: ---</div>
 
         <div id="settings_infoblock">
           <div id="settings_close" class="settingsCloseBox"></div>
@@ -1114,6 +1115,8 @@
     <script src="layers.js"></script>
     <script src="geomag2020.js"></script>
     <script src="markers.js"></script>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js" crossorigin="anonymous"></script>
 
     <!-- JS_ANCHOR3 -->
     <script src="planeObject.js"></script>

--- a/html/style.css
+++ b/html/style.css
@@ -124,7 +124,7 @@ select {
     cursor: pointer;
     border: none;
     background: transparent;
-    color: var(--TXTCOLOR2);
+    color: #000;
     border-radius: 4px;
 }
 
@@ -146,6 +146,67 @@ select {
 
 #drawing_toolbar button svg path {
     fill: currentColor;
+}
+
+/* Measurement label and QR styles */
+.measure-label {
+    position: absolute;
+    transform: translate(-50%, -100%);
+    pointer-events: none;
+}
+
+.measure-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: #fff;
+    color: #000;
+    border: 1px solid #000;
+    padding: 3px 8px;
+    border-radius: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+    line-height: 1.25;
+    box-sizing: border-box;
+    box-shadow: 0 0 0 2px rgba(0,0,0,.08);
+    pointer-events: auto;
+}
+
+.measure-chip .qr-toggle {
+    pointer-events: auto;
+    cursor: pointer;
+    border: 0;
+    background: transparent;
+    font-size: 12px;
+    line-height: 1;
+    padding-left: 2px;
+}
+
+.qr-label .qr-img {
+    width: 78px;
+    height: 78px;
+    background: #fff;
+    border: 5px solid #fff;
+    border-radius: 10px;
+    padding: 4px;
+    box-sizing: content-box;
+    box-shadow: 0 2px 10px rgba(0,0,0,.12), 0 0 0 1px rgba(0,0,0,.15);
+}
+
+/* Mouse coordinate display */
+#mouse-coordinates {
+    position: absolute;
+    bottom: 5px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(255,255,255,0.9);
+    padding: 3px 8px;
+    border-radius: 6px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.3);
+    font-size: 12px;
+    z-index: 1000;
+    pointer-events: none;
 }
 
 .sidebar_button {


### PR DESCRIPTION
## Summary
- color drawing toolbar icons black and add QR/measurement styles
- show mouse coordinates in footer and update on pointer move
- use marker icon with coordinate/QR overlay for point drawings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bafd3357108333af7503d798bbc077